### PR TITLE
OPS-5237 Disable desktop notifications in vagrant

### DIFF
--- a/src/sst/runtests.py
+++ b/src/sst/runtests.py
@@ -459,24 +459,32 @@ class SSTTestCase(testtools.TestCase):
             self.session_name = str(self)
 
     def start_browser(self):
-        if self.vagrant_enabled:
-            if self.browser_type == 'ANDROID':
-                self.add_additional_capabilities({
-                    'chromeOptions': {
-                        'args': [
-                            'window-size=480,800',
-                            'user-agent="Mozilla/5.0 (Linux; Android 4.2.1; en-us; Nexus 5 Build/JOP40D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19"',
-                            'test-type'
-                        ]
-                    }
-                })
-            else:
-                self.add_additional_capabilities({
-                    'chromeOptions': {
-                        'args': ['test-type'],
-                        'prefs': {'profile.managed_default_content_settings.notifications': 2},
-                    }
-                })
+        if self.vagrant_enabled and self.browser_type == 'ANDROID':
+            self.add_additional_capabilities({
+                'chromeOptions': {
+                    'args': [
+                        'window-size=480,800',
+                        'user-agent="Mozilla/5.0 (Linux; Android 4.2.1; en-us; Nexus 5 Build/JOP40D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19"',
+                        'test-type'
+                    ]
+                }
+            })
+        else:
+            # Disable Desktop notifications (default: 3)
+            # https://www.chromium.org/administrators/policy-list-3#DefaultNotificationsSetting
+            # https://code.google.com/p/chromium/codesearch#chromium/src/chrome/test/chromedriver/client/chromedriver.py&sq=package:chromium&dr=C&l=127
+            self.add_additional_capabilities({
+                'chromeOptions': {
+                    'args': ['test-type'],
+                    'prefs': {
+                        'profile': {
+                            'managed_default_content_settings': {
+                                'notifications': 2
+                            },
+                        },
+                    },
+                }}
+            })
         print 'Reminder: SSL certificates are auto-accepted, only use --vagrant in a testing environment.'
 
         self.browser, self.browsermob_proxy = start(

--- a/src/sst/runtests.py
+++ b/src/sst/runtests.py
@@ -483,7 +483,7 @@ class SSTTestCase(testtools.TestCase):
                             },
                         },
                     },
-                }}
+                }
             })
         print 'Reminder: SSL certificates are auto-accepted, only use --vagrant in a testing environment.'
 

--- a/src/sst/runtests.py
+++ b/src/sst/runtests.py
@@ -473,7 +473,8 @@ class SSTTestCase(testtools.TestCase):
             else:
                 self.add_additional_capabilities({
                     'chromeOptions': {
-                        'args': ['test-type']
+                        'args': ['test-type'],
+                        'prefs': {'profile.managed_default_content_settings.notifications': 2},
                     }
                 })
         print 'Reminder: SSL certificates are auto-accepted, only use --vagrant in a testing environment.'


### PR DESCRIPTION
See JIRA task for the API reference.

Testing:
```
bin/run_selenium_tests.py -D wfu_list test_x_joblist_pager_navigation --browserstack
```
See on Browserstack − fails on current master when the Chrome popup to allow desktop notifications appears.